### PR TITLE
feat: Add configurable announcement types and multi-line support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
 # KartaAutoAnnouncer
 
-KartaAutoAnnouncer is a lightweight and easy-to-use Spigot plugin designed to broadcast automated messages to your Minecraft server. It supports various message types, including chat, action bar, and titles, ensuring your announcements are seen.
+KartaAutoAnnouncer is a lightweight, flexible, and easy-to-use Spigot plugin designed to broadcast automated messages to your Minecraft server. It supports various message types and gives you full control over your announcements.
 
 ## Features
 
-- **Multiple Announcement Types**: Broadcast messages in chat, on the action bar, or as a screen title.
-- **Easy Configuration**: A clean and simple configuration file.
-- **In-Game Commands**: Reload the configuration, add new messages, and set the announcement interval directly from the game.
+- **Flexible Announcement Types**: Broadcast messages in chat, on the action bar, or as a screen title. Each type can be individually enabled or disabled.
+- **Multi-line Chat Support**: Create detailed announcements with multiple lines in a single chat message.
+- **Toggleable Prefix**: You can now enable or disable the prefix for chat messages.
+- **Easy Configuration**: A clean and simple configuration file that is easy to understand and modify.
+- **In-Game Commands**: Reload the configuration and set the announcement interval directly from the game.
 - **PlaceholderAPI Support**: Use placeholders from other plugins in your announcements.
 - **Hex Color Support**: Use hex color codes (e.g., `&#RRGGBB`) for vibrant messages.
 
@@ -18,26 +20,46 @@ KartaAutoAnnouncer is a lightweight and easy-to-use Spigot plugin designed to br
 
 ## Configuration
 
-The `config.yml` file is located in the `plugins/KartaAutoAnnouncer` directory. Here's an overview of the default configuration:
+The `config.yml` file is located in the `plugins/KartaAutoAnnouncer` directory. Here's an overview of the new configuration structure:
 
 ```yaml
 # The interval in seconds between each announcement.
 interval: 60
 
-# The prefix to be displayed before every CHAT announcement.
-# This does not apply to ACTION_BAR or TITLE messages.
-prefix: "&d[Karta] &r"
+# Prefix settings for CHAT announcements.
+prefix:
+  # Set to true to enable the prefix, false to disable it.
+  enabled: true
+  # The text to be displayed as the prefix.
+  text: "&d[Karta] &r"
 
 # A list of messages to be broadcast.
+# You can enable or disable each announcement type individually.
+# Color codes (&a, &b, etc.) and hex colors (&#RRGGBB) are supported in all text fields.
 announcements:
   chat:
-    - "&aWelcome to our server! We hope you have a great time."
-    - "&6Don't forget to join our Discord!"
+    # Set to true to enable chat announcements, false to disable.
+    enabled: true
+    messages:
+      - "This is a single-line chat message."
+      - [
+          "This is a multi-line message.",
+          "This is the second line."
+        ]
   action_bar:
-    - "&bMake sure to read the &c&l/rules&b."
+    # Set to true to enable action bar announcements, false to disable.
+    enabled: true
+    messages:
+      - "&aThis is an action bar message."
+      - "&eCheck out our website!"
   title:
-    - title: "&#4287f5Vote for us!"
-      subtitle: "&eUse the /vote command for rewards!"
+    # Set to true to enable title announcements, false to disable.
+    enabled: true
+    messages:
+      - title: "&6Welcome!"
+        subtitle: "&fEnjoy your stay on our server."
+      - title: "&cVote for us!"
+        subtitle: "&fReceive rewards for your support."
 ```
 
 ## Commands & Permissions
@@ -48,29 +70,10 @@ The main command is `/kaa` (alias for `/kartaautoannouncer`).
 
 ### Sub-commands
 
-- `/kaa reload` - Reloads the configuration file.
-- `/kaa setinterval <seconds>` - Sets the interval between announcements.
-- `/kaa add <type> <message>` - Adds a new announcement.
+- `/kaa reload` - Reloads the configuration file from disk.
+- `/kaa setinterval <seconds>` - Sets the interval between announcements and saves it to the config.
 
-### Adding Announcements
-
-You can add announcements directly in-game using the `/kaa add` command.
-
-- **Type**: `chat`, `actionbar`, or `title`.
-
-**Examples:**
-
-- **Chat:**
-  `/kaa add chat &aThis is a new chat message!`
-
-- **Action Bar:**
-  `/kaa add actionbar &bCheck out our new store!`
-
-- **Title:**
-  `/kaa add title &6Big News! | &eWe have a new event!`
-  *(The pipe `|` character separates the title from the subtitle.)*
-
-After adding a new message, you must run `/kaa reload` to apply the changes.
+**Note**: After using `/kaa setinterval`, you still need to run `/kaa reload` to apply the new interval. Adding and removing messages should be done by editing the `config.yml` file.
 
 ## Support
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.minekarta</groupId>
     <artifactId>KartaAutoAnnouncer</artifactId>
-    <version>1.3.0</version>
+    <version>1.4.0</version>
     <packaging>jar</packaging>
 
     <name>KartaAutoAnnouncer</name>

--- a/src/main/java/com/minekarta/autoannouncer/AnnouncementMessages.java
+++ b/src/main/java/com/minekarta/autoannouncer/AnnouncementMessages.java
@@ -1,0 +1,59 @@
+package com.minekarta.autoannouncer;
+
+import org.bukkit.configuration.file.FileConfiguration;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class AnnouncementMessages {
+    private final AutoAnnouncer plugin;
+    private final List<Announcement> announcements = new ArrayList<>();
+
+    public AnnouncementMessages(AutoAnnouncer plugin) {
+        this.plugin = plugin;
+    }
+
+    public void loadAnnouncements() {
+        announcements.clear();
+        FileConfiguration config = plugin.getConfig();
+
+        if (!config.isConfigurationSection("announcements")) {
+            return;
+        }
+
+        // Chat messages
+        if (config.getBoolean("announcements.chat.enabled", false) && config.isList("announcements.chat.messages")) {
+            config.getList("announcements.chat.messages").forEach(obj -> {
+                if (obj instanceof String) {
+                    announcements.add(new Announcement(AnnouncementType.CHAT, (String) obj, null));
+                } else if (obj instanceof List) {
+                    String message = String.join("\n", (List<String>) obj);
+                    announcements.add(new Announcement(AnnouncementType.CHAT, message, null));
+                }
+            });
+        }
+
+        // Action bar messages
+        if (config.getBoolean("announcements.action_bar.enabled", false) && config.isList("announcements.action_bar.messages")) {
+            config.getStringList("announcements.action_bar.messages").forEach(text ->
+                    announcements.add(new Announcement(AnnouncementType.ACTION_BAR, text, null))
+            );
+        }
+
+        // Title messages
+        if (config.getBoolean("announcements.title.enabled", false) && config.isList("announcements.title.messages")) {
+            config.getMapList("announcements.title.messages").forEach(map -> {
+                String title = (String) map.get("title");
+                String subtitle = (String) map.get("subtitle");
+                if (title != null) {
+                    announcements.add(new Announcement(AnnouncementType.TITLE, title, subtitle));
+                }
+            });
+        }
+    }
+
+    public List<Announcement> getAnnouncements() {
+        return announcements;
+    }
+}

--- a/src/main/java/com/minekarta/autoannouncer/AutoAnnouncer.java
+++ b/src/main/java/com/minekarta/autoannouncer/AutoAnnouncer.java
@@ -14,93 +14,71 @@ public class AutoAnnouncer extends JavaPlugin {
 
     private BukkitTask announcementTask;
     public boolean papiEnabled = false;
+    private AnnouncementMessages announcementMessages;
 
     @Override
     public void onEnable() {
         saveDefaultConfig();
+        announcementMessages = new AnnouncementMessages(this);
 
         if (getServer().getPluginManager().getPlugin("PlaceholderAPI") != null) {
-            this.papiEnabled = true;
+            papiEnabled = true;
             getLogger().info("Successfully hooked into PlaceholderAPI.");
         }
 
-        // Register command executor
-        Objects.requireNonNull(getCommand("minekartaautoannouncer"), "Command not found in plugin.yml")
-               .setExecutor(new CommandManager(this));
+        Objects.requireNonNull(getCommand("kartaautoannouncer"), "Command not found in plugin.yml")
+                .setExecutor(new CommandManager(this));
+
         startAnnouncerTask();
     }
 
     public void reloadPlugin() {
-        // Cancel the current task
         if (announcementTask != null && !announcementTask.isCancelled()) {
             announcementTask.cancel();
         }
-        // Reload the config file from disk
         reloadConfig();
-        // Start the task with the new settings
+        announcementMessages.loadAnnouncements();
         startAnnouncerTask();
-        getLogger().info("AutoAnnouncer configuration reloaded.");
+        getLogger().info("KartaAutoAnnouncer configuration reloaded.");
     }
 
     private void startAnnouncerTask() {
-        String prefix = getConfig().getString("prefix", "&d[Minekarta] &r");
-        int interval = getConfig().getInt("interval", 60);
-
-        List<Announcement> announcements = new ArrayList<>();
-        if (getConfig().isConfigurationSection("announcements")) {
-            // Chat messages
-            getConfig().getStringList("announcements.chat").forEach(text ->
-                    announcements.add(new Announcement(AnnouncementType.CHAT, text, null))
-            );
-
-            // Action bar messages
-            getConfig().getStringList("announcements.action_bar").forEach(text ->
-                    announcements.add(new Announcement(AnnouncementType.ACTION_BAR, text, null))
-            );
-
-            // Title messages
-            if (getConfig().isList("announcements.title")) {
-                getConfig().getMapList("announcements.title").forEach(map -> {
-                    String title = (String) map.get("title");
-                    String subtitle = (String) map.get("subtitle");
-                    if (title != null) {
-                        announcements.add(new Announcement(AnnouncementType.TITLE, title, subtitle));
-                    }
-                });
-            }
-        }
+        announcementMessages.loadAnnouncements();
+        List<Announcement> announcements = announcementMessages.getAnnouncements();
 
         if (announcements.isEmpty()) {
-            getLogger().warning("No valid announcements found in config.yml. The announcer will not start.");
+            getLogger().warning("No announcements loaded. The announcer will not start.");
             return;
         }
 
+        int interval = getConfig().getInt("interval", 60);
         if (interval <= 0) {
             getLogger().warning("The announcement interval must be positive. The announcer will not start.");
             return;
         }
 
-        long period = interval * 20L;
-        announcementTask = new AnnouncementTask(this, announcements, prefix, papiEnabled).runTaskTimer(this, 0L, period);
+        String prefix = getConfig().getString("prefix.text", "&d[Karta] &r");
+        boolean prefixEnabled = getConfig().getBoolean("prefix.enabled", true);
 
-        getLogger().info("AutoAnnouncer task has been started/reloaded with " + announcements.size() + " announcements, running every " + interval + " seconds.");
+        long period = interval * 20L;
+        announcementTask = new AnnouncementTask(announcements, prefix, papiEnabled, prefixEnabled)
+                .runTaskTimer(this, 0L, period);
+
+        getLogger().info("AutoAnnouncer task started with " + announcements.size() + " announcements, running every " + interval + " seconds.");
     }
 
     @Override
     public void onDisable() {
-        // Cancel the task when the plugin is disabled
         if (announcementTask != null && !announcementTask.isCancelled()) {
             announcementTask.cancel();
         }
-        getLogger().info("Minekarta-Auto-Announcer has been disabled.");
+        getLogger().info("KartaAutoAnnouncer has been disabled.");
     }
 
-    // Helper method to convert strings with legacy/hex codes to Adventure Components
     public static Component createComponent(String text) {
         if (text == null) {
             return Component.empty();
         }
-        // This serializer handles both legacy '&' codes and hex '&#RRGGBB' codes
         return LegacyComponentSerializer.legacyAmpersand().deserialize(text);
     }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,31 +1,38 @@
 # Configuration for KartaAutoAnnouncer
-#
 # The interval in seconds between each announcement.
 interval: 60
 
-# The prefix to be displayed before every CHAT announcement.
-# This does not apply to ACTION_BAR or TITLE messages.
-prefix: "&d[Karta] &r"
+# Prefix settings for CHAT announcements.
+prefix:
+  # Set to true to enable the prefix, false to disable it.
+  enabled: true
+  # The text to be displayed as the prefix.
+  text: "&d[Karta] &r"
 
 # A list of messages to be broadcast.
-#
-# Supported types:
-# - CHAT: A standard chat message. Will be prefixed with the 'prefix' above.
-# - ACTION_BAR: A message that appears above the player's hotbar.
-# - TITLE: A large title message that appears in the center of the screen.
-#
-# For TITLE messages, you can also add a 'subtitle'.
-#
+# You can enable or disable each announcement type individually.
 # Color codes (&a, &b, etc.) and hex colors (&#RRGGBB) are supported in all text fields.
 announcements:
   chat:
-    - "message 1"
-    - "message 2"
+    # Set to true to enable chat announcements, false to disable.
+    enabled: true
+    messages:
+      - "This is a single-line chat message."
+      - [
+          "This is a multi-line message.",
+          "This is the second line."
+        ]
   action_bar:
-    - "action bar 1"
-    - "action bar 2"
+    # Set to true to enable action bar announcements, false to disable.
+    enabled: true
+    messages:
+      - "&aThis is an action bar message."
+      - "&eCheck out our website!"
   title:
-    - title: "title 1"
-      subtitle: "subtitle 1"
-    - title: "title 2"
-      subtitle: "subtitle 2"
+    # Set to true to enable title announcements, false to disable.
+    enabled: true
+    messages:
+      - title: "&6Welcome!"
+        subtitle: "&fEnjoy your stay on our server."
+      - title: "&cVote for us!"
+        subtitle: "&fReceive rewards for your support."


### PR DESCRIPTION
This commit introduces several new features and improvements to the KartaAutoAnnouncer plugin.

- **Configurable Announcement Types:** Each announcement type (chat, action_bar, title) can now be individually enabled or disabled in the `config.yml`.
- **Multi-line Chat:** Chat announcements now support multi-line messages by using a list of strings in the configuration.
- **Toggleable Prefix:** The prefix for chat announcements can now be enabled or disabled via the `config.yml`.
- **Code Refactoring:** Introduced an `AnnouncementMessages` class to handle loading announcements, improving code organization.
- **Updated Documentation:** The `README.md` has been rewritten to reflect all new features and the updated configuration structure.